### PR TITLE
feat: Add dependency resolution and content search

### DIFF
--- a/llmfiles/config/settings.py
+++ b/llmfiles/config/settings.py
@@ -21,13 +21,30 @@ class ChunkStrategy(Enum):
             log.warning("invalid_chunk_strategy_string", input_string=s)
             return None
 
+class ExternalDepsStrategy(Enum):
+    # defines how to handle external dependencies.
+    IGNORE = "ignore"
+    METADATA = "metadata"
+
+    @classmethod
+    def from_string(cls, s: Optional[str]) -> "ExternalDepsStrategy":
+        if not s:
+            return cls.IGNORE
+        try:
+            return cls(s.lower())
+        except ValueError:
+            log.warning("invalid_external_deps_strategy", input_string=s)
+            return cls.IGNORE
+
 @dataclass
 class PromptConfig:
     # holds all configuration parameters for a single run.
     input_paths: List[Path] = field(default_factory=list)
     include_patterns: List[str] = field(default_factory=list)
     exclude_patterns: List[str] = field(default_factory=list)
+    grep_content_pattern: Optional[str] = None
     chunk_strategy: ChunkStrategy = ChunkStrategy.STRUCTURE
+    external_deps_strategy: ExternalDepsStrategy = ExternalDepsStrategy.IGNORE
     no_ignore: bool = False
     hidden: bool = False
     follow_symlinks: bool = False

--- a/llmfiles/core/discovery/dependency_resolver.py
+++ b/llmfiles/core/discovery/dependency_resolver.py
@@ -1,0 +1,67 @@
+# llmfiles/core/discovery/dependency_resolver.py
+import sys
+from pathlib import Path
+from typing import Tuple, Optional, Literal, Set
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+ResolutionStatus = Literal["internal", "external", "stdlib", "unresolved"]
+
+# A basic set of standard library modules to avoid false positives.
+# This is not exhaustive but covers many common cases.
+STD_LIB_MODULES = set(sys.stdlib_module_names)
+
+def resolve_import(
+    import_name: str,
+    project_root: Path,
+    installed_packages: Set[str],
+) -> Tuple[ResolutionStatus, Optional[Path | str]]:
+    """
+    Resolves a Python import name to a file path or categorizes it.
+
+    This function implements a "simple path mapping" strategy. It tries to map
+    a given import name (e.g., 'my_app.core.utils') to a corresponding file
+    or package directory within the project root.
+
+    Args:
+        import_name: The dot-separated import string (e.g., "my_app.utils").
+        project_root: The root directory of the project to search within.
+        installed_packages: A set of package names installed in the environment.
+
+    Returns:
+        A tuple containing:
+        - The resolution status ('internal', 'external', 'stdlib', 'unresolved').
+        - The result: a Path object for 'internal' imports, the import name
+          for 'external' or 'stdlib' imports, or None for 'unresolved'.
+    """
+    # 1. Check if it's a standard library module
+    top_level_module = import_name.split('.')[0]
+    if top_level_module in STD_LIB_MODULES:
+        log.debug("import_resolved_as_stdlib", import_name=import_name)
+        return "stdlib", import_name
+
+    # 2. Check if it's a known installed external package
+    if top_level_module in installed_packages:
+        log.debug("import_resolved_as_external", import_name=import_name)
+        return "external", import_name
+
+    # 3. Attempt to resolve as an internal project file
+    path_parts = import_name.split('.')
+
+    # Check for file: /path/to/project/part1/part2.py
+    potential_file_path = project_root.joinpath(*path_parts).with_suffix(".py")
+    if potential_file_path.is_file():
+        log.debug("import_resolved_as_internal_file", import_name=import_name, path=str(potential_file_path))
+        return "internal", potential_file_path.relative_to(project_root)
+
+    # Check for package: /path/to/project/part1/part2/__init__.py
+    potential_package_path = project_root.joinpath(*path_parts, "__init__.py")
+    if potential_package_path.is_file():
+        log.debug("import_resolved_as_internal_package", import_name=import_name, path=str(potential_package_path))
+        return "internal", potential_package_path.relative_to(project_root)
+
+    # 4. If all else fails, mark as unresolved
+    log.debug("import_unresolved", import_name=import_name)
+    return "unresolved", None

--- a/llmfiles/core/pipeline.py
+++ b/llmfiles/core/pipeline.py
@@ -8,12 +8,25 @@ from rich.console import Console as RichConsole
 import structlog
 import logging as stdlib_logging
 
+import collections
 from llmfiles.config.settings import PromptConfig
-from llmfiles.core.discovery.walker import discover_paths
+from llmfiles.core.discovery.walker import discover_paths, grep_files_for_content
 from llmfiles.core.processing import process_file_content_to_elements
 from llmfiles.exceptions import SmartPromptBuilderError
+from llmfiles.structured_processing.language_parsers.python_parser import extract_python_imports
+from llmfiles.core.discovery.dependency_resolver import resolve_import
+
 
 log = structlog.get_logger(__name__)
+
+
+# TODO: This should be dynamically sourced, not hardcoded.
+# For now, using the list from pyproject.toml is sufficient for the logic.
+INSTALLED_PACKAGES = {
+    "click", "pathspec", "rich", "structlog",
+    "tree-sitter", "tree-sitter-language-pack"
+}
+
 
 class PromptGenerator:
     # orchestrates the prompt generation pipeline.
@@ -21,6 +34,7 @@ class PromptGenerator:
         self.config: PromptConfig = config
         self.log = structlog.get_logger(f"{__name__}.{self.__class__.__name__}")
         self.content_elements: List[Dict[str, Any]] = []
+        self.external_dependencies: Dict[str, Set[str]] = collections.defaultdict(set)
 
     def _render_final_output(self) -> str:
         # renders the collected content elements into the final markdown string.
@@ -29,11 +43,17 @@ class PromptGenerator:
 
         output_parts.append(f"project root: {project_root_name}")
 
-        unique_file_paths = sorted(list(set(el["file_path"] for el in self.content_elements)))
-        if unique_file_paths:
+        # Group elements by file path to structure the output
+        elements_by_file = collections.defaultdict(list)
+        for el in self.content_elements:
+            elements_by_file[el["file_path"]].append(el)
+
+        sorted_file_paths = sorted(elements_by_file.keys())
+
+        if sorted_file_paths:
             tree_lines = [f"{project_root_name}/"]
-            for i, path_str in enumerate(unique_file_paths):
-                prefix = "└── " if i == len(unique_file_paths) - 1 else "├── "
+            for i, path_str in enumerate(sorted_file_paths):
+                prefix = "└── " if i == len(sorted_file_paths) - 1 else "├── "
                 tree_lines.append(f"{prefix}{path_str}")
 
             output_parts.append("\nproject structure (based on included content):\n```text")
@@ -42,25 +62,75 @@ class PromptGenerator:
 
         if self.content_elements:
             output_parts.append("\ncontent elements:")
-            for element in self.content_elements:
+            for file_path in sorted_file_paths:
                 output_parts.append("---")
-                output_parts.append(f"element type: {element.get('element_type', 'unknown')}")
-                if element.get('name'):
-                    output_parts.append(f"name: {element.get('name')}")
-                if element.get('qualified_name'):
-                    output_parts.append(f"qualified name: {element.get('qualified_name')}")
-                output_parts.append(f"source file: {element.get('file_path')}")
-                output_parts.append(f"lines: {element.get('start_line')}-{element.get('end_line')}")
-                output_parts.append(f"language hint: {element.get('language')}")
-                if element.get('docstring'):
-                    output_parts.append("docstring:\n```")
-                    output_parts.append(element.get('docstring'))
-                    output_parts.append("```")
-                output_parts.append("content:")
-                output_parts.append(f"{element.get('llm_formatted_content')}")
+                output_parts.append(f"source file: {file_path}")
+
+                # Add external dependency metadata if requested
+                if self.config.external_deps_strategy == "metadata" and file_path in self.external_dependencies:
+                    deps = sorted(list(self.external_dependencies[file_path]))
+                    if deps:
+                        output_parts.append("external dependencies:")
+                        for dep in deps:
+                            output_parts.append(f"  - {dep}")
+
+                # Render each element within the file
+                for element in elements_by_file[file_path]:
+                    output_parts.append(f"--- (element: {element.get('qualified_name', element.get('name', 'N/A'))})")
+                    output_parts.append(f"element type: {element.get('element_type', 'unknown')}")
+                    if element.get('qualified_name'):
+                        output_parts.append(f"qualified name: {element.get('qualified_name')}")
+                    output_parts.append(f"lines: {element.get('start_line')}-{element.get('end_line')}")
+                    output_parts.append(f"language hint: {element.get('language')}")
+                    if element.get('docstring'):
+                        output_parts.append("docstring:\n```")
+                        output_parts.append(element.get('docstring'))
+                        output_parts.append("```")
+                    output_parts.append("content:")
+                    output_parts.append(f"{element.get('llm_formatted_content')}")
+
             output_parts.append("---")
 
         return "\n".join(output_parts) + "\n"
+
+    def _resolve_dependencies(self, seed_files: List[Path]) -> List[Path]:
+        """
+        Performs dependency resolution to build a complete list of files.
+        """
+        worklist = collections.deque(seed_files)
+        processed_files = set(seed_files)
+
+        self.log.info("starting_dependency_resolution", seed_count=len(seed_files))
+
+        while worklist:
+            current_file = worklist.popleft()
+
+            if not current_file.suffix == ".py":
+                self.log.debug("skipping_non_python_file_for_deps", file=str(current_file))
+                continue
+
+            try:
+                content_bytes = current_file.read_bytes()
+                imports = extract_python_imports(content_bytes)
+            except Exception as e:
+                self.log.warning("failed_to_extract_imports", file=str(current_file), error=str(e))
+                continue
+
+            for import_name in imports:
+                status, result = resolve_import(import_name, self.config.base_dir, INSTALLED_PACKAGES)
+
+                if status == "internal":
+                    new_file_path = self.config.base_dir / result
+                    if new_file_path not in processed_files:
+                        self.log.debug("discovered_internal_dependency", source=str(current_file), target=str(new_file_path))
+                        processed_files.add(new_file_path)
+                        worklist.append(new_file_path)
+                elif status in ["external", "stdlib"]:
+                    rel_path_str = str(current_file.relative_to(self.config.base_dir))
+                    self.external_dependencies[rel_path_str].add(result)
+
+        return sorted(list(processed_files))
+
 
     def generate(self) -> Tuple[str, List[str]]:
         # runs the full pipeline and returns the final prompt and list of included files.
@@ -73,16 +143,28 @@ class PromptGenerator:
             transient=True, disable=progress_disabled, console=stderr_console
         ) as progress:
 
-            discover_task = progress.add_task("discovering paths...", total=None)
-            paths_to_process = list(discover_paths(self.config))
-            progress.update(discover_task, completed=True, description=f"discovered {len(paths_to_process)} files.")
+            discover_task = progress.add_task("discovering seed files...", total=None)
+
+            # Determine the seeding strategy
+            if self.config.grep_content_pattern:
+                # Grep mode: seeds are determined by content search
+                seed_files = list(grep_files_for_content(self.config))
+            else:
+                # Standard mode: seeds are from paths and patterns
+                seed_files = list(discover_paths(self.config))
+            progress.update(discover_task, completed=True, description=f"discovered {len(seed_files)} seed files.")
+
+            # New dependency resolution step
+            resolve_task = progress.add_task("resolving dependencies...", total=None)
+            paths_to_process = self._resolve_dependencies(seed_files)
+            progress.update(resolve_task, completed=True, description=f"total files to include: {len(paths_to_process)}")
 
             if paths_to_process:
                 processing_task = progress.add_task("processing content...", total=len(paths_to_process))
                 for file_path in paths_to_process:
                     elements_from_file = process_file_content_to_elements(file_path, self.config)
                     self.content_elements.extend(elements_from_file)
-                    progress.update(processing_task, advance=1)
+                    progress.update(processing_task, advance=1, description=f"processing {file_path.name}")
 
         if not self.content_elements:
             return "", []

--- a/llmfiles/structured_processing/language_parsers/python_parser.py
+++ b/llmfiles/structured_processing/language_parsers/python_parser.py
@@ -84,3 +84,18 @@ def extract_python_elements(file_path: Path, project_root: Path, content_bytes: 
 
     log.debug("extracted_python_elements", file=rel_path, count=len(elements))
     return elements
+
+def extract_python_imports(content_bytes: bytes) -> List[str]:
+    # parses python code and extracts all unique import module names.
+    imports = set()
+    ast = ts.parse_code_to_ast(content_bytes, LANG)
+    if not ast:
+        return []
+
+    import_captures = ts.run_query("imports", LANG, ast)
+    for node, _ in import_captures:
+        import_text = ts.get_node_text(node, content_bytes)
+        imports.add(import_text)
+
+    log.debug("extracted_python_imports", count=len(imports))
+    return sorted(list(imports))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,1 +1,71 @@
-# llmfiles/tests/test_cli.py
+import pytest
+from pathlib import Path
+from click.testing import CliRunner
+from llmfiles.cli.interface import main_cli_group
+
+@pytest.fixture
+def cli_project(tmp_path: Path):
+    """Creates a mock project for testing the CLI end-to-end."""
+    proj_dir = tmp_path / "cli_proj"
+    proj_dir.mkdir()
+
+    (proj_dir / "helpers.py").write_text("def helper_func():\n    return 'I am a helper with a MAGIC_KEYWORD'\n")
+    (proj_dir / "utils.py").write_text("import numpy\nfrom helpers import helper_func\n\ndef util_func():\n    return helper_func()\n")
+    (proj_dir / "main.py").write_text("from utils import util_func\n\nif __name__ == '__main__':\n    util_func()\n")
+    (proj_dir / "unrelated.py").write_text("# This file should not be included.")
+
+    return proj_dir
+
+def test_cli_end_to_end_dependency_resolution():
+    """
+    Tests the full CLI with dependency resolution starting from a single file.
+    """
+    runner = CliRunner()
+    with runner.isolated_filesystem() as td:
+        proj_dir = Path(td)
+        (proj_dir / "helpers.py").write_text("def helper_func(): return 'helper'")
+        (proj_dir / "utils.py").write_text("import numpy\nfrom helpers import helper_func\n\ndef util_func(): return helper_func()")
+        (proj_dir / "main.py").write_text("from utils import util_func\n\nif __name__ == '__main__': util_func()")
+        (proj_dir / "unrelated.py").write_text("# Not imported")
+
+        result = runner.invoke(
+            main_cli_group,
+            ["main.py", "--external-deps", "metadata"],
+            catch_exceptions=False
+        )
+
+        assert result.exit_code == 0
+        output = result.output
+        assert "source file: main.py" in output
+        assert "source file: utils.py" in output
+        assert "source file: helpers.py" in output
+        assert "source file: unrelated.py" not in output
+        assert "external dependencies:" in output
+        assert "- numpy" in output
+
+def test_cli_end_to_end_grep_seed():
+    """
+    Tests the full CLI using --grep-content to seed the dependency resolution.
+    """
+    runner = CliRunner()
+    with runner.isolated_filesystem() as td:
+        proj_dir = Path(td)
+        (proj_dir / "helpers.py").write_text("def helper_func(): return 'helper'")
+        (proj_dir / "utils.py").write_text("import numpy\nfrom helpers import helper_func\n\ndef util_func(): return helper_func()")
+        (proj_dir / "main.py").write_text("from utils import util_func\n# MAGIC_KEYWORD\n\nif __name__ == '__main__': util_func()")
+        (proj_dir / "unrelated.py").write_text("# Not imported")
+
+        result = runner.invoke(
+            main_cli_group,
+            [".", "--grep-content", "MAGIC_KEYWORD", "--external-deps", "metadata"],
+            catch_exceptions=False
+        )
+
+        assert result.exit_code == 0
+        output = result.output
+        assert "source file: main.py" in output
+        assert "source file: utils.py" in output
+        assert "source file: helpers.py" in output
+        assert "source file: unrelated.py" not in output
+        assert "external dependencies:" in output
+        assert "- numpy" in output

--- a/tests/test_dependency_resolution.py
+++ b/tests/test_dependency_resolution.py
@@ -1,0 +1,76 @@
+import pytest
+from pathlib import Path
+from llmfiles.structured_processing.language_parsers.python_parser import extract_python_imports
+from llmfiles.core.discovery.dependency_resolver import resolve_import
+
+# --- Tests for extract_python_imports ---
+
+def test_extract_simple_imports():
+    code = b"import os\nimport sys\n"
+    imports = extract_python_imports(code)
+    assert set(imports) == {"os", "sys"}
+
+def test_extract_from_imports():
+    code = b"from pathlib import Path\nfrom typing import List, Dict\n"
+    imports = extract_python_imports(code)
+    assert set(imports) == {"pathlib", "typing"}
+
+def test_extract_dotted_imports():
+    code = b"import my_pkg.my_module\nfrom my_pkg.utils import helper\n"
+    imports = extract_python_imports(code)
+    assert set(imports) == {"my_pkg.my_module", "my_pkg.utils"}
+
+def test_extract_no_imports():
+    code = b"print('Hello, world!')\n"
+    imports = extract_python_imports(code)
+    assert imports == []
+
+def test_extract_imports_with_aliases():
+    code = b"import numpy as np\nfrom pandas import DataFrame as DF\n"
+    imports = extract_python_imports(code)
+    assert set(imports) == {"numpy", "pandas"}
+
+# --- Tests for resolve_import ---
+
+@pytest.fixture
+def mock_project(tmp_path: Path):
+    """Creates a mock project structure in a temporary directory."""
+    proj_dir = tmp_path / "project"
+    proj_dir.mkdir()
+
+    # a/b/c.py
+    (proj_dir / "a" / "b").mkdir(parents=True)
+    (proj_dir / "a" / "b" / "c.py").touch()
+
+    # d/e/__init__.py
+    (proj_dir / "d" / "e").mkdir(parents=True)
+    (proj_dir / "d" / "e" / "__init__.py").touch()
+
+    return proj_dir
+
+INSTALLED_PACKAGES = {"numpy", "pandas"}
+
+def test_resolve_internal_file(mock_project: Path):
+    status, result = resolve_import("a.b.c", mock_project, INSTALLED_PACKAGES)
+    assert status == "internal"
+    assert result == Path("a/b/c.py")
+
+def test_resolve_internal_package(mock_project: Path):
+    status, result = resolve_import("d.e", mock_project, INSTALLED_PACKAGES)
+    assert status == "internal"
+    assert result == Path("d/e/__init__.py")
+
+def test_resolve_external_package(mock_project: Path):
+    status, result = resolve_import("numpy", mock_project, INSTALLED_PACKAGES)
+    assert status == "external"
+    assert result == "numpy"
+
+def test_resolve_stdlib_package(mock_project: Path):
+    status, result = resolve_import("os", mock_project, INSTALLED_PACKAGES)
+    assert status == "stdlib"
+    assert result == "os"
+
+def test_resolve_unresolved_package(mock_project: Path):
+    status, result = resolve_import("scipy.linalg", mock_project, INSTALLED_PACKAGES)
+    assert status == "unresolved"
+    assert result is None

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,1 +1,59 @@
-# llmfiles/tests/test_discovery.py
+import pytest
+from pathlib import Path
+from llmfiles.config.settings import PromptConfig
+from llmfiles.core.discovery.walker import grep_files_for_content
+
+@pytest.fixture
+def grep_project(tmp_path: Path):
+    """Creates a mock project for testing grep functionality."""
+    proj_dir = tmp_path / "grep_proj"
+    proj_dir.mkdir()
+
+    (proj_dir / "file_with_keyword.txt").write_text("hello this file has the MAGIC_KEYWORD inside.")
+    (proj_dir / "another_with_keyword.py").write_text("# python file with MAGIC_KEYWORD")
+    (proj_dir / "file_without.txt").write_text("this file is clean.")
+
+    # Create a subdirectory with a file
+    (proj_dir / "sub").mkdir()
+    (proj_dir / "sub" / "sub_file_with_keyword.txt").write_text("nested MAGIC_KEYWORD here")
+
+    return proj_dir
+
+def test_grep_files_for_content(grep_project: Path):
+    # Change current directory to the parent of the grep_project for predictable paths
+    import os
+    os.chdir(grep_project.parent)
+
+    config = PromptConfig(
+        input_paths=[grep_project],
+        grep_content_pattern="MAGIC_KEYWORD"
+    )
+
+    # Since PromptConfig post_init sets base_dir to cwd, we adjust it for the test
+    config.base_dir = grep_project
+
+    found_files = list(grep_files_for_content(config))
+
+    assert len(found_files) == 3
+
+    found_paths = {p.relative_to(grep_project) for p in found_files}
+    expected_paths = {
+        Path("file_with_keyword.txt"),
+        Path("another_with_keyword.py"),
+        Path("sub/sub_file_with_keyword.txt")
+    }
+    assert found_paths == expected_paths
+
+def test_grep_files_no_matches(grep_project: Path):
+    import os
+    os.chdir(grep_project.parent)
+
+    config = PromptConfig(
+        input_paths=[grep_project],
+        grep_content_pattern="NOT_A_KEYWORD"
+    )
+    config.base_dir = grep_project
+
+    found_files = list(grep_files_for_content(config))
+
+    assert len(found_files) == 0


### PR DESCRIPTION
This commit introduces several major enhancements to improve how `llmfiles` builds context from Python codebases.

A new dependency resolution pipeline has been added. When processing Python files, the tool now parses their import statements. It can distinguish between internal project modules, installed external libraries, and standard library modules. By recursively resolving and including all internal dependencies starting from a set of "seed" files, the tool can now gather a much more complete and relevant context for an LLM.

To improve the initial discovery of relevant files, this change adds a new `--grep-content` command-line option. This allows a user to provide a text pattern to search for within files, using the matches as the initial seeds for the dependency resolution process.

Finally, a new `--external-deps` flag has been added with an option (`metadata`) to list a file's external and standard library dependencies in the final output, making the context even more informative.

A comprehensive suite of unit and integration tests has been added to cover this new functionality.