### PR TITLE
feat: Add dependency resolution and content search

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ it moves beyond simple file concatenation by using tree-sitter to parse code int
 
 ## features
 
+-   **recursive dependency resolution:** for python, automatically finds and includes files that are imported by your seed files, providing much richer context.
+-   **content-based file search:** use the `--grep-content` flag to select files based on a text pattern in their content, not just their file path.
 -   **intelligent code chunking:** automatically parses supported languages (python, javascript) into logical units like functions and classes.
 -   **fallback to file chunking:** gracefully handles unsupported file types by treating them as a single element.
 -   **`.gitignore` aware:** respects your project's `.gitignore` files by default.
@@ -55,6 +57,33 @@ sometimes you want to disable semantic chunking and just get the content of each
 llmfiles --chunk-strategy file --include "src/**/*.py"
 ```
 
+**example 5: automatic dependency resolution**
+
+start with a single entrypoint file, and `llmfiles` will follow its internal imports to build a comprehensive context.
+
+```bash
+# main.py imports utils.py, which imports helpers.py
+# llmfiles will automatically include all three files in the output.
+llmfiles src/main.py
+```
+
+**example 6: find files by content (`grep`)**
+
+you don't know the file name, but you know it contains the text "qwen image edit". use `--grep-content` to find it and all of its dependencies.
+
+```bash
+llmfiles . --grep-content "qwen image edit"
+```
+
+**example 7: list external dependencies**
+
+to see which external libraries a file depends on, use `--external-deps metadata`.
+
+```bash
+llmfiles src/utils.py --external-deps metadata
+```
+this will add a list of packages like `numpy` or `pandas` to the output for that file.
+
 ## all options
 
 ```text
@@ -71,10 +100,15 @@ options:
                           multiple times.
   -e, --exclude pattern   glob pattern for files to exclude. can be used
                           multiple times.
+  --grep-content pattern  search file contents for a pattern and include
+                          matching files as seeds for dependency resolution.
   --chunk-strategy [structure|file]
                           strategy for chunking files. 'structure' (default)
                           uses ast parsing for supported languages. 'file'
                           treats each file as a single chunk.
+  --external-deps [ignore|metadata]
+                          strategy for handling external dependencies: 'ignore'
+                          or 'metadata'.
   --no-ignore             do not respect .gitignore files.
   --hidden                include hidden files and directories (starting with
                           a dot).


### PR DESCRIPTION
This commit introduces several major enhancements to improve how `llmfiles` builds context from Python codebases.

A new dependency resolution pipeline has been added. When processing Python files, the tool now parses their import statements. It can distinguish between internal project modules, installed external libraries, and standard library modules. By recursively resolving and including all internal dependencies starting from a set of "seed" files, the tool can now gather a much more complete and relevant context for an LLM.

To improve the initial discovery of relevant files, this change adds a new `--grep-content` command-line option. This allows a user to provide a text pattern to search for within files, using the matches as the initial seeds for the dependency resolution process.

A new `--external-deps` flag has been added with an option (`metadata`) to list a file's external and standard library dependencies in the final output, making the context even more informative.

A comprehensive suite of unit and integration tests has been added to cover this new functionality.

Finally, the `README.md` has been updated to document all new features and command-line options.